### PR TITLE
fix: add placeholder watchmanconfig for fixing RootResolveError

### DIFF
--- a/examples/simple-watcher/.watchmanconfig
+++ b/examples/simple-watcher/.watchmanconfig
@@ -1,0 +1,5 @@
+{
+  "root_files": [
+    ".watchmanconfig"
+  ]
+}


### PR DESCRIPTION
for #20 

To let watchman watch the example folder, we can specify the example dir as root dir.