### PR TITLE
Add `empty_on_fresh_instance` option to `Subscribe`

### DIFF
--- a/protocol/subscribe.go
+++ b/protocol/subscribe.go
@@ -36,8 +36,9 @@ package protocol
 //
 // See also: https://facebook.github.io/watchman/docs/cmd/subscribe.html
 type SubscribeRequest struct {
-	Root string
-	Name string
+	Root                 string
+	Name                 string
+	EmptyOnFreshInstance bool
 }
 
 // Args returns values used to encode a request PDU.
@@ -46,7 +47,11 @@ func (req *SubscribeRequest) Args() []interface{} {
 		"fields": []string{
 			"cclock", "ctime", "exists", "gid", "mode", "mtime", "name",
 			"nlink", "oclock", "size", "symlink_target", "type", "uid",
-		}}
+		},
+	}
+	if req.EmptyOnFreshInstance {
+		m["empty_on_fresh_instance"] = true
+	}
 	return []interface{}{"subscribe", req.Root, req.Name, m}
 }
 

--- a/protocol/subscribe_test.go
+++ b/protocol/subscribe_test.go
@@ -12,10 +12,12 @@ func TestSubscribe(t *testing.T) {
 	require := require.New(t)
 
 	for _, tc := range []struct {
-		request  string
-		response string
-		req      *SubscribeRequest
-		res      *SubscribeResponse
+		request      string
+		response     string
+		req          *SubscribeRequest
+		res          *SubscribeResponse
+		clock        string
+		subscription string
 	}{
 		{
 			request: `["subscribe","/tmp","sub1",{"fields":[` +
@@ -39,6 +41,34 @@ func TestSubscribe(t *testing.T) {
 				clock:        "c:1531594843:978:9:345",
 				subscription: "sub1",
 			},
+			clock:        "c:1531594843:978:9:345",
+			subscription: "sub1",
+		},
+		{
+			request: `["subscribe","/tmp","sub2",{"empty_on_fresh_instance":true,"fields":[` +
+				`"cclock","ctime","exists","gid","mode","mtime","name",` +
+				`"nlink","oclock","size","symlink_target","type","uid"` +
+				"]}]\n",
+			response: `{"clock":"c:1531594843:978:9:346","subscribe":"sub2","version":"4.9.0"}` + "\n",
+			req: &SubscribeRequest{
+				Root:                 "/tmp",
+				Name:                 "sub2",
+				EmptyOnFreshInstance: true,
+			},
+			res: &SubscribeResponse{
+				response: response{
+					pdu: ResponsePDU{
+						"version":   "4.9.0",
+						"clock":     "c:1531594843:978:9:346",
+						"subscribe": "sub2",
+					},
+					version: "4.9.0",
+				},
+				clock:        "c:1531594843:978:9:346",
+				subscription: "sub2",
+			},
+			clock:        "c:1531594843:978:9:346",
+			subscription: "sub2",
 		},
 	} {
 		requested := &bytes.Buffer{}
@@ -60,8 +90,8 @@ func TestSubscribe(t *testing.T) {
 		require.Equal(tc.res, actual)
 		require.Equal("", actual.Warning())
 		require.Equal("4.9.0", actual.Version())
-		require.Equal("c:1531594843:978:9:345", actual.Clock())
-		require.Equal("sub1", actual.Subscription())
+		require.Equal(tc.clock, actual.Clock())
+		require.Equal(tc.subscription, actual.Subscription())
 	}
 }
 

--- a/watch.go
+++ b/watch.go
@@ -29,11 +29,19 @@ func (w *Watch) Clock(syncTimeout time.Duration) (clock string, err error) {
 	return
 }
 
+// SubscribeOptions configures an optional set of parameters for Subscribe.
+type SubscribeOptions struct {
+	EmptyOnFreshInstance bool
+}
+
 // Subscribe requests notification when changes occur under a watched root.
-func (w *Watch) Subscribe(name, root string) (s *Subscription, err error) {
+func (w *Watch) Subscribe(name, root string, opts ...*SubscribeOptions) (s *Subscription, err error) {
 	req := &protocol.SubscribeRequest{
 		Name: name,
 		Root: root,
+	}
+	if len(opts) > 0 && opts[0] != nil {
+		req.EmptyOnFreshInstance = opts[0].EmptyOnFreshInstance
 	}
 	_, err = w.client.send(req)
 	if err == nil {


### PR DESCRIPTION
- Add `EmptyOnFreshInstance` field to `protocol.SubscribeRequest`; `Args()` omits the key when false so wire format is unchanged for existing callers
- Add `SubscribeOptions` struct to high-level API with variadic `opts ...*SubscribeOptions` parameter — no breaking change
- Add test case covering serialization of the new field